### PR TITLE
fix: サプライチェーン攻撃対策を実施

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,12 +2,15 @@ name: publish on release
 
 on: [release]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1.2.0
 
       - name: install dependencies
         run: yarn

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,12 +2,15 @@ name: react-infinite-scroll-component
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1.2.0
 
       - name: install dependencies
         run: yarn
@@ -24,7 +27,7 @@ jobs:
       - name: ts type checks
         run: yarn ts-check
 
-      - uses: codecov/codecov-action@v1.0.3
+      - uses: codecov/codecov-action@d5749ba79ad0a1647198e63bc2f564d3ccf436a9 # v1.0.3
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           file: ./coverage/lcov.info

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -27,7 +27,7 @@ jobs:
       - name: ts type checks
         run: yarn ts-check
 
-      - uses: codecov/codecov-action@d5749ba79ad0a1647198e63bc2f564d3ccf436a9 # v1.0.3
+      - uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
           token: ${{secrets.CODECOV_TOKEN}}
-          file: ./coverage/lcov.info
+          files: ./coverage/lcov.info

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-registry=https://us-npm.pkg.dev/canary-dev-214513/assuredoss-npm/
-//us-npm.pkg.dev/canary-dev-214513/assuredoss-npm/:always-auth=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry=https://us-npm.pkg.dev/canary-dev-214513/assuredoss-npm/
+//us-npm.pkg.dev/canary-dev-214513/assuredoss-npm/:always-auth=true


### PR DESCRIPTION
## 背景
[サプライチェーン攻撃を防ぐための対策](https://www.notion.so/canary-inc/33a1009a77028060968cfbe5aed5ecde) に基づき、セキュリティ対策を実施。

## 変更内容
- publish.yml, push.yml のアクション参照をSHAピン留めに変更（actions/checkout@v1, codecov/codecov-action@v1.0.3）
- 両ワークフローに permissions: contents: read を追加
- .npmrc を追加（Assured OSS レジストリ設定）

## Reference
- Notion: https://www.notion.so/canary-inc/33a1009a77028060968cfbe5aed5ecde