### PR TITLE
chore: pin third-party GitHub Actions to commit SHA

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1
 
       - name: install dependencies
         run: yarn

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -24,7 +24,7 @@ jobs:
       - name: ts type checks
         run: yarn ts-check
 
-      - uses: codecov/codecov-action@d5749ba79ad0a1647198e63bc2f564d3ccf436a9 # v1.0.3
+      - uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
           token: ${{secrets.CODECOV_TOKEN}}
-          file: ./coverage/lcov.info
+          files: ./coverage/lcov.info

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1
 
       - name: install dependencies
         run: yarn
@@ -24,7 +24,7 @@ jobs:
       - name: ts type checks
         run: yarn ts-check
 
-      - uses: codecov/codecov-action@v1.0.3
+      - uses: codecov/codecov-action@d5749ba79ad0a1647198e63bc2f564d3ccf436a9 # v1.0.3
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           file: ./coverage/lcov.info


### PR DESCRIPTION
## 概要

サードパーティの GitHub Actions 参照をタグ参照 (`@v1`, `@v1.0.3`) からコミット SHA に変更します。あわせて `codecov/codecov-action` を v5.5.4 に bump します (v1.x は node12 / EOL Docker image 依存で動作不能のため)。

## 背景

本対応は GitHub Org 全体で SHA pinning を強制化するための取り組みの一環です。

GitHub Actions のタグは作者が再付け替え可能なため、サプライチェーン攻撃のリスクがあります。OpenSSF / GitHub のベストプラクティスに従い、コミット SHA で pinning し、タグはコメントとして残します。

## 変更点

- `.github/workflows/publish.yml`:
  - `actions/checkout@v1` → `actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1`
- `.github/workflows/push.yml`:
  - `actions/checkout@v1` → `actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1`
  - `codecov/codecov-action@v1.0.3` → `codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4` (v1.0.3 は EOL の `debian:stretch-slim` ベースの Docker action で apt repo が 404 を返し動作しないため、最新の v5.5.4 に bump)
  - 同 step の input 名を v5 系の仕様に合わせて `file:` → `files:` に変更

## 動作確認

- CI (push workflow) が green になることで pinning + 修復を確認。

## 参考

- https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
- https://github.com/codecov/codecov-action/releases/tag/v5.5.4
